### PR TITLE
Added close modal on Escape press

### DIFF
--- a/lib/components/modals/reusable_modal_live.ex
+++ b/lib/components/modals/reusable_modal_live.ex
@@ -93,6 +93,13 @@ defmodule Bonfire.UI.Common.ReusableModalLive do
     @default_assigns
   end
 
+  def handle_event("close-key", %{"key" => key} = attrs, socket) do
+    case key do
+      "Escape" -> handle_event("close", %{}, socket)
+      _ -> socket
+    end
+  end
+
   def handle_event("close", _, socket) do
     debug(
       "reset all assigns to defaults so they don't accidentally get re-used in a different modal"

--- a/lib/components/modals/reusable_modal_live.sface
+++ b/lib/components/modals/reusable_modal_live.sface
@@ -37,6 +37,7 @@
     x-transition:leave-end="opacity-0"
     x-description="Background backdrop, show/hide based on modal state."
     phx-click="close"
+    phx-window-keydown="close-key"
     phx-target={"[id='#{@id}']"}
     class="fixed inset-0 transition-opacity bg-slate-600/60 backdrop-blur-md -z-1"
     aria-hidden="true"


### PR DESCRIPTION
addressing https://github.com/bonfire-networks/bonfire-app/issues/961

I tested it manually on image preview, circles creation and edit. 

Let me know if there are some examples to create automated tests of this behavior or if I should add this feature to some other modal handler.
